### PR TITLE
Declare pycryptodome as an optional dependency called 'accelerated'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Optional: (better performance with C ciphers)
 
 .. code:: rst
 
-  $ pip3 install pycryptodome
+  $ pip3 install pproxy[accelerated]
   Successfully installed pycryptodome-3.6.4
 
 Apply OS system-wide proxy: (MacOS, Windows)

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,11 @@ setup(
     ],
     keywords='proxy socks http shadowsocks redirect tunnel cipher ssl',
     packages=['pproxy'],
+    extras_require={
+        'accelerated': [
+            'pycryptodome',
+        ],
+    },
     install_requires=[],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
[extras_require](https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies) is a mechanism for declaring dependencies of optional features. Having this allows users of the package to install the crypto acceleration even if the underlying crypto library is changed.