### PR TITLE
added Docker documentation to Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,14 @@ Apply CLI proxy: (MacOS, Linux)
   $ export http_proxy=http://localhost:8080 
   $ export https_proxy=http://localhost:8080 
 
+
+Run With Docker 
+----------
+
+`pproxy` Docker container comes with C optimizations pre-installed.
+
+```docker run -it -p 8080:8080 mosajjal/pproxy:1.9.1 pproxy -l http://:8080 -vv```
+
 Features
 --------
 

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Run With Docker
 
 `pproxy` Docker container comes with C optimizations pre-installed.
 
-```docker run -it -p 8080:8080 mosajjal/pproxy:1.9.1 pproxy -l http://:8080 -vv```
+```docker run -it -p 8080:8080 mosajjal/pproxy pproxy -l http://:8080 -vv```
 
 Features
 --------


### PR DESCRIPTION
I've recently created a Docker image for ```pproxy``` with C extensions installed. It provides a one-command running of the server. Just added it to Readme for people to use. 