### PR TITLE
sshtunnel as optional dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ setup(
         'accelerated': [
             'pycryptodome >= 3.7.2',
         ],
+        'sshtunnel': [
+            'asyncssh >= 1.16.0',
+        ],
     },
     install_requires    = [],
     entry_points        = {


### PR DESCRIPTION
It's a very simple change but I think it could be more consistent with the design of `pproxy`