### PR TITLE
parse hostname without port

### DIFF
--- a/pproxy/server.py
+++ b/pproxy/server.py
@@ -482,7 +482,7 @@ class ProxyURI(object):
                     cipher.plugins.append(plugin)
         match = cls.compile_rule(url.query) if url.query else None
         if loc:
-            host_name, _, port = loc.rpartition(':')
+            host_name, _, port = loc.partition(':')
             port = int(port) if port else (22 if 'ssh' in rawprotos else 8080)
         else:
             host_name = port = None


### PR DESCRIPTION
Test case:
pproxy -r socks5://10.0.0.1
Actual behavior:
pproxy: error: argument -r: invalid compile_relay value: 'socks5://10.0.0.1'
Expected behavior:
pproxy started