### PR TITLE
Include LICENSE and tests in PyPI sdist and wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+graft tests


### PR DESCRIPTION
Fixes #91

Besides tests as requested in #91, I also include the LICENSE file for following Arch Linux's packaging guidelines [1].

With this change, sdist and wheel sizes are increased but still quite small:
```
-rw-r--r-- 1 yen yen 46482 2020/12/05 22:08:53 orig/pproxy-2.4.7.tar.gz
-rw-r--r-- 1 yen yen 50180 2020/12/05 21:45:26 dist/pproxy-2.4.7.tar.gz
-rw-r--r-- 1 yen yen 38509 2020/12/05 22:08:58 orig/pproxy-2.4.7-py3-none-any.whl
-rw-r--r-- 1 yen yen 39306 2020/12/05 22:09:30 dist/pproxy-2.4.7-py3-none-any.whl
```
Here are lists of newly included files as for version 2.4.7. For sdist,
```
 pproxy-2.4.7/
+pproxy-2.4.7/LICENSE
+pproxy-2.4.7/MANIFEST.in
 pproxy-2.4.7/PKG-INFO
 pproxy-2.4.7/README.rst
 pproxy-2.4.7/pproxy/
@@ -21,3 +23,9 @@
 pproxy-2.4.7/pproxy.egg-info/top_level.txt
 pproxy-2.4.7/setup.cfg
 pproxy-2.4.7/setup.py
+pproxy-2.4.7/tests/
+pproxy-2.4.7/tests/api_client.py
+pproxy-2.4.7/tests/api_server.py
+pproxy-2.4.7/tests/cipher_compare.py
+pproxy-2.4.7/tests/cipher_speed.py
+pproxy-2.4.7/tests/cipher_verify.py
```
For the wheel,
```
+pproxy-2.4.7.dist-info/LICENSE
 pproxy-2.4.7.dist-info/METADATA
 pproxy-2.4.7.dist-info/RECORD
 pproxy-2.4.7.dist-info/WHEEL
```

[1] https://wiki.archlinux.org/index.php/PKGBUILD#license