### PR TITLE
Obey RFC2616 in CONNECT request

### DIFF
--- a/pproxy/proto.py
+++ b/pproxy/proto.py
@@ -328,8 +328,8 @@ class HTTP(BaseProtocol):
                 writer.write(f'{method} {newpath} {ver}\r\n{lines}\r\n\r\n'.encode())
                 return True
             return user, host_name, port, connected
-    async def connect(self, reader_remote, writer_remote, rauth, host_name, port, myhost, **kw):
-        writer_remote.write(f'CONNECT {host_name}:{port} HTTP/1.1\r\nHost: {myhost}'.encode() + (b'\r\nProxy-Authorization: Basic '+base64.b64encode(rauth) if rauth else b'') + b'\r\n\r\n')
+    async def connect(self, reader_remote, writer_remote, rauth, host_name, port, **kw):
+        writer_remote.write(f'CONNECT {host_name}:{port} HTTP/1.1\r\nHost: {host_name}:{port}'.encode() + (b'\r\nProxy-Authorization: Basic '+base64.b64encode(rauth) if rauth else b'') + b'\r\n\r\n')
         await reader_remote.read_until(b'\r\n\r\n')
     async def http_channel(self, reader, writer, stat_bytes, stat_conn):
         try:


### PR DESCRIPTION
Some proxy servers requires `Host` header to be the same as CONNECT or they will return 400 http code on request.

RFC2616 tells us the same thing

https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
>An HTTP/1.1 proxy MUST ensure that any request message it forwards does contain an appropriate Host header field that >identifies the service being requested by the proxy. All Internet-based HTTP/1.1 servers MUST respond with a 400 (Bad >Request) status code to any HTTP/1.1 request message which lacks a Host header field.

Before the change
```
CONNECT ifconfig.co:443 HTTP/1.1
Host: PROXY_IP
Proxy-Authorization: Basic --base64data--
```

After the change
```
CONNECT ifconfig.co:443 HTTP/1.1
Host: ifconfig.co:443
Proxy-Authorization: Basic --base64data--
```
