### PR TITLE
feat: httpadmin protocol for external control

### DIFF
--- a/pproxy/admin.py
+++ b/pproxy/admin.py
@@ -1,0 +1,39 @@
+import json
+import asyncio
+config = {}
+
+
+async def reply_http(reply, ver, code, content):
+    await reply(code, f'{ver} {code}\r\nConnection: close\r\nContent-Type: text/plain\r\nCache-Control: max-age=900\r\nContent-Length: {len(content)}\r\n\r\n'.encode(), content, True)
+
+
+async def status_handler(reply, **kwarg):
+    method = kwarg.get('method')
+    if method == 'GET':
+        data = {"status": "ok"}
+        value = json.dumps(data).encode()
+        ver = kwarg.get('ver')
+        await reply_http(reply, ver, '200 OK', value)
+
+
+async def configs_handler(reply, **kwarg):
+    method = kwarg.get('method')
+    ver = kwarg.get('ver')
+
+    if method == 'GET':
+        data = {"argv": config['argv']}
+        value = json.dumps(data).encode()
+        await reply_http(reply, ver, '200 OK', value)
+    elif method == 'POST':
+        config['argv'] = kwarg.get('content').decode().split(' ')
+        config['reload'] = True
+        data = {"result": 'ok'}
+        value = json.dumps(data).encode()
+        await reply_http(reply, ver, '200 OK', value)
+        raise KeyboardInterrupt
+
+
+httpget = {
+    '/status': status_handler,
+    '/configs': configs_handler,
+}


### PR DESCRIPTION
## idea
clash-core has `external control` that support restful api for external control. That makes it easy for third part GUI to manipulate it. So I think it's a good idea for python proxy.

This pr is draft for this idea.  I'd like to hear your suggestions about it. :)

## usage
Add a new protocol called `httpadmin`, which handle http request. So user can add admin port: 

```python
% pproxy -l http://localhost:8080 -l httpadmin://localhost:8081
```

At beginning stage, two api entries are added.

Show server status

```python
% curl 'localhost:8081/status'
```

Show server configs (list argv)

```python
% curl 'localhost:8081/configs'
```

Modify server configs (use new argv)

```python
% curl 'localhost:8081/configs' -X POST -d '-l http://localhost:8082 -l httpadmin://localhost:8081'
```

## known issues (todo)
- it's dangerous to expose admin port, auth is necessary
- hot reload uses `raise KeyInterrupt`, maybe there's more elegant way

