### PR TITLE
relay requested port to destination for SimpleProxy

### DIFF
--- a/pproxy/server.py
+++ b/pproxy/server.py
@@ -270,7 +270,7 @@ class ProxySimple(ProxyDirect):
         data = self.cipher.datagram.decrypt(data) if self.cipher else data
         return self.jump.udp_packet_unpack(self.rproto.udp_unpack(data))
     def destination(self, host, port):
-        return self.host_name, self.port
+        return self.host_name, self.port if self.port != 0 else port
     def udp_prepare_connection(self, host, port, data):
         data = self.jump.udp_prepare_connection(host, port, data)
         whost, wport = self.jump.destination(host, port)
@@ -289,7 +289,7 @@ class ProxySimple(ProxyDirect):
         if self.unix:
             return asyncio.open_unix_connection(path=self.bind)
         else:
-            return asyncio.open_connection(host=self.host_name, port=self.port, local_addr=local_addr, family=family)
+            return asyncio.open_connection(host=self.host_name, port=self.port if self.port != 0 else port, local_addr=local_addr, family=family)
     async def prepare_connection(self, reader_remote, writer_remote, host, port):
         reader_remote, writer_remote = proto.sslwrap(reader_remote, writer_remote, self.sslclient, False, self.host_name)
         _, writer_cipher_r = await prepare_ciphers(self.cipher, reader_remote, writer_remote, self.bind)


### PR DESCRIPTION
I have a need to redirect all requests on any port of a host to a different host, and I don't think this is covered by the current URI syntax. I'm sure it can be discussed what the optimal implementation for this is, but the PR seems the easiest way to get this feature into the current implementation and URI syntax.

Say that I run a web UI program on `host.example.com` and which listens to localhost. I now want to access it in a web browser on my own machine via an ssh tunnel. If the program uses port 8088, I can do, e.g., this:
```
pproxy -r ssh://host.example.com/?host.example.com#login::key__httponly://localhost:8088/"
```
However, lets say the program on host2 uses unpredictable port numbers (perhaps it dynamically opens them). I just want to map `host.example.com:<port> -> ssh to host.example.com -> localhost:<port>` for any `<port>`. If I omit the port number in the destination URI above, pproxy uses the default value of 8088.

This PR allows using the request port as the destination port for anything covered by SimpleProxy by specifying the destination port as `0` (traditionally used to mean "any port" when opening ports, so it seems somewhat appropriate). 

After merging, this PR enables the following syntax for the above example:
```
pproxy -r ssh://host.example.com/?host.example.com#login::key__httponly://localhost:0/"
``` 