### PR TITLE
Optimize print_server_started() to avoid throw an exception when using the QUIC protocol.

### DIFF
--- a/pproxy/server.py
+++ b/pproxy/server.py
@@ -886,8 +886,13 @@ def print_server_started(option, server, print_fn):
     sockets=[]
     if hasattr(server, 'sockets'): # asyncio.Server or uvloop.loop.Server
         sockets.extend(server.sockets)
+    elif hasattr(server, 'get_extra_info'): # asyncio.Transport or uvloop.loop.UDPTransport
+        sockets.append(server.get_extra_info('socket'))
     elif hasattr(server, '_transport'): # aioquic.asyncio.server.QuicServer
         sockets.append(server._transport.get_extra_info('socket'))
+    else:
+        print_fn(option, None)
+        return
     for s in sockets:
         # https://github.com/MagicStack/uvloop/blob/master/uvloop/pseudosock.pyx
         host, port = s.getsockname() # tuple size varies with protocol family

--- a/pproxy/server.py
+++ b/pproxy/server.py
@@ -895,7 +895,7 @@ def print_server_started(option, server, print_fn):
         return
     for s in sockets:
         # https://github.com/MagicStack/uvloop/blob/master/uvloop/pseudosock.pyx
-        host, port = s.getsockname() # tuple size varies with protocol family
+        host, port = s.getsockname()[:2] # tuple size varies with protocol family
         ipversion = "ipv?"
         if s.family == socket.AddressFamily.AF_INET:
             ipversion = "ipv4"


### PR DESCRIPTION
When using the QUIC protocol, an exception will be thrown:

> (python-3.12.8) root@server:/root/python-proxy# pproxy -v -l quic+http://127.0.0.1:8080 --ssl ssl.crt,ssl.key
> Using uvloop
> Serving on 127.0.0.1:8080 by http
> Start server failed.
> 	==> 'QuicServer' object has no attribute 'sockets'